### PR TITLE
Delay initialization until rundeck has bootstrapped

### DIFF
--- a/rundeck-execution-mode-timer/grails-app/init/com/rundeck/plugin/BootStrap.groovy
+++ b/rundeck-execution-mode-timer/grails-app/init/com/rundeck/plugin/BootStrap.groovy
@@ -2,30 +2,4 @@ package com.rundeck.plugin
 
 class BootStrap {
 
-    def executionModeService
-    def updateModeProjectService
-
-
-    def timer(String name,Closure clos){
-        long bstart=System.currentTimeMillis()
-        log.debug("BEGIN: ${name}")
-        def res=clos()
-        log.debug("${name} in ${System.currentTimeMillis()-bstart}ms")
-        return res
-    }
-
-    def init = { servletContext ->
-
-        timer("executionModeService.init") {
-            executionModeService.initProcess()
-        }
-
-        timer("updateModeProjectService.init") {
-            updateModeProjectService.initProcess()
-        }
-
-
-    }
-    def destroy = {
-    }
 }

--- a/rundeck-execution-mode-timer/grails-app/services/com/rundeck/plugin/BootStrapService.groovy
+++ b/rundeck-execution-mode-timer/grails-app/services/com/rundeck/plugin/BootStrapService.groovy
@@ -1,0 +1,28 @@
+package com.rundeck.plugin
+
+import grails.events.annotation.Subscriber
+
+class BootStrapService {
+
+    def executionModeService
+    def updateModeProjectService
+
+    def timer(String name,Closure clos){
+        long bstart=System.currentTimeMillis()
+        log.debug("BEGIN: ${name}")
+        def res=clos()
+        log.debug("${name} in ${System.currentTimeMillis()-bstart}ms")
+        return res
+    }
+
+    @Subscriber("rundeck.bootstrap")
+    void init() {
+        timer("executionModeService.init") {
+            executionModeService.initProcess()
+        }
+
+        timer("updateModeProjectService.init") {
+            updateModeProjectService.initProcess()
+        }
+    }
+}

--- a/rundeck-execution-mode-timer/src/main/groovy/com/rundeck/plugin/EnableLaterExecutionsPluginGrailsPlugin.groovy
+++ b/rundeck-execution-mode-timer/src/main/groovy/com/rundeck/plugin/EnableLaterExecutionsPluginGrailsPlugin.groovy
@@ -5,7 +5,6 @@ import grails.plugins.*
 
 class EnableLaterExecutionsPluginGrailsPlugin extends Plugin {
 
-    def loadAfter = ['rundeckapp']
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "3.3.10 > *"
     // resources that are excluded from plugin packaging

--- a/rundeck-execution-mode-timer/src/main/groovy/com/rundeck/plugin/EnableLaterExecutionsPluginGrailsPlugin.groovy
+++ b/rundeck-execution-mode-timer/src/main/groovy/com/rundeck/plugin/EnableLaterExecutionsPluginGrailsPlugin.groovy
@@ -5,6 +5,7 @@ import grails.plugins.*
 
 class EnableLaterExecutionsPluginGrailsPlugin extends Plugin {
 
+    def loadAfter = ['rundeckapp']
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "3.3.10 > *"
     // resources that are excluded from plugin packaging


### PR DESCRIPTION
Fixes #7

Potential fix for #7 . At the very end of the main application bootstrap it emits the `rundeck.bootstrap` event. This PR centralizes the init process and kicks off in response to the message.

Downside to this is the initialization is asynchronous. It may be inappropriate for the application to continue to load without this plugin having initialized. 