### PR TITLE
RUN-3622 Fix CVE-2022-38749

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,7 @@ jobs:
         id: get_version
         run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
       - name: Upload execution-mode-timer-plugin jar
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           # Artifact name
           name: Grails-Plugin-${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Get Fetch Tags
         run: git -c protocol.version=2 fetch --tags --progress --no-recurse-submodules origin
         if: "!contains(github.ref, 'refs/tags')"
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: '11'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 assetPluginVersion=3.4.3
 rundeckVersion=3.4.4-20210920
-snakeyamlVersion=1.28
+snakeyamlVersion=2.2

--- a/rundeck-execution-mode-timer/gradle.properties
+++ b/rundeck-execution-mode-timer/gradle.properties
@@ -1,5 +1,5 @@
-grailsVersion=5.1.6
-grailsGradlePluginVersion=5.1.2
+grailsVersion=6.1.2
+grailsGradlePluginVersion=6.1.2
 gormVersion=7.1.2
 groovyVersion=3.0.9
 gradleWrapperVersion=7.2


### PR DESCRIPTION
This PR addresses https://github.com/advisories/GHSA-c4r9-r8fh-9vj2 by upgrading vulnerable dependencies, specifically updating the SnakeYAML library and Grails framework versions to patch security vulnerabilities.